### PR TITLE
make navbar background transparent on miui/hyperos

### DIFF
--- a/app/src/main/java/cn/ac/lz233/tarnhelm/ui/BaseActivity.kt
+++ b/app/src/main/java/cn/ac/lz233/tarnhelm/ui/BaseActivity.kt
@@ -2,6 +2,7 @@ package cn.ac.lz233.tarnhelm.ui
 
 import android.content.Context
 import android.content.res.Configuration
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
@@ -23,10 +24,9 @@ abstract class BaseActivity : AppCompatActivity(), CoroutineScope by MainScope()
             window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
         }
         WindowCompat.setDecorFitsSystemWindows(window, false)
-    }
-
-    override fun onStart() {
-        super.onStart()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+        }
     }
 
     override fun attachBaseContext(newBase: Context) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.1.2' apply false
-    id 'com.android.library' version '8.1.2' apply false
+    id 'com.android.application' version '8.1.4' apply false
+    id 'com.android.library' version '8.1.4' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.10' apply false
     id 'dev.rikka.tools.materialthemebuilder' version '1.3.1'
     id 'com.google.devtools.ksp' version '1.9.10-1.0.13' apply false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Aug 14 17:11:44 CST 2022
+#Sun Nov 26 11:53:56 CST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-rc-4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
使 Tarnhelm 在 MIUI/HyperOS 上导航栏沉浸。

| Before | After |
|:---|:---|
|![Screenshot_2023-11-26-14-26-32-121_cn ac lz233 tarnhelm](https://github.com/lz233/Tarnhelm/assets/93428659/269d5880-e86c-486b-9a8b-45682ea474b4)|![Screenshot_2023-11-26-14-25-41-988_cn ac lz233 tarnhelm](https://github.com/lz233/Tarnhelm/assets/93428659/ec2a52bb-597b-44b5-b448-176005a87382)|

在类原生上手势导航沉浸效果不变，三键导航沉浸。